### PR TITLE
Add pragma pack around packed structures for MSVC.

### DIFF
--- a/apps/debug/client/remsrv.h
+++ b/apps/debug/client/remsrv.h
@@ -116,6 +116,8 @@ Members:
 
 --*/
 
+#pragma pack(push, 1)
+
 typedef struct _DEBUG_REMOTE_HEADER {
     ULONG Magic;
     ULONG Command;
@@ -216,6 +218,8 @@ typedef struct _DEBUG_REMOTE_SOURCE_DATA {
     DEBUG_REMOTE_HEADER Header;
     ULONG FileNameCrc32;
 } PACKED DEBUG_REMOTE_SOURCE_DATA, *PDEBUG_REMOTE_SOURCE_DATA;
+
+#pragma pack(pop)
 
 /*++
 

--- a/apps/debug/client/stabs.h
+++ b/apps/debug/client/stabs.h
@@ -247,6 +247,8 @@ Members:
 
 --*/
 
+#pragma pack(push, 1)
+
 typedef struct _RAW_STAB {
     ULONG StringIndex;
     UCHAR Type;
@@ -254,6 +256,8 @@ typedef struct _RAW_STAB {
     USHORT Description;
     ULONG Value;
 } PACKED RAW_STAB, *PRAW_STAB;
+
+#pragma pack(pop)
 
 //
 // ----------------------------------------------- Internal Function Prototypes

--- a/apps/libc/dynamic/net.h
+++ b/apps/libc/dynamic/net.h
@@ -97,6 +97,8 @@ Members:
 
 --*/
 
+#pragma pack(push, 1)
+
 typedef struct _DNS_HEADER {
     USHORT Identifier;
     USHORT Flags;
@@ -105,6 +107,8 @@ typedef struct _DNS_HEADER {
     USHORT NameServerCount;
     USHORT AdditionalResourceCount;
 } PACKED DNS_HEADER, *PDNS_HEADER;
+
+#pragma pack(pop)
 
 //
 // -------------------------------------------------------------------- Globals

--- a/apps/libc/dynamic/time.c
+++ b/apps/libc/dynamic/time.c
@@ -114,6 +114,8 @@ Members:
 
 --*/
 
+#pragma pack(push, 1)
+
 typedef struct _CUSTOM_TIME_ZONE {
     TIME_ZONE_HEADER Header;
     TIME_ZONE_RULE StandardRule;
@@ -122,6 +124,8 @@ typedef struct _CUSTOM_TIME_ZONE {
     TIME_ZONE_ENTRY ZoneEntry;
     CHAR Strings[32];
 } PACKED CUSTOM_TIME_ZONE, *PCUSTOM_TIME_ZONE;
+
+#pragma pack(pop)
 
 /*++
 

--- a/boot/lib/include/bios.h
+++ b/boot/lib/include/bios.h
@@ -119,6 +119,8 @@ Members:
 
 --*/
 
+#pragma pack(push, 1)
+
 typedef struct _INT13_DISK_ACCESS_PACKET {
     UCHAR PacketSize;
     UCHAR Reserved;
@@ -169,6 +171,8 @@ typedef struct _INT13_EXTENDED_DRIVE_PARAMETERS {
     USHORT SectorSize;
     ULONG EnhancedDiskInformation;
 } PACKED INT13_EXTENDED_DRIVE_PARAMETERS, *PINT13_EXTENDED_DRIVE_PARAMETERS;
+
+#pragma pack(pop)
 
 //
 // -------------------------------------------------------------------- Globals

--- a/boot/lib/pcat/int10.c
+++ b/boot/lib/pcat/int10.c
@@ -194,6 +194,8 @@ Members:
 
 --*/
 
+#pragma pack(push, 1)
+
 typedef struct _VESA_INFORMATION {
     ULONG Signature;
     USHORT VesaVersion;
@@ -352,6 +354,8 @@ typedef struct _VESA_MODE_INFORMATION {
     USHORT OffScreenMemorySize;
     //UCHAR Reserved2[206];
 } PACKED VESA_MODE_INFORMATION, *PVESA_MODE_INFORMATION;
+
+#pragma pack(pop)
 
 /*++
 

--- a/drivers/ahci/ahci.h
+++ b/drivers/ahci/ahci.h
@@ -527,6 +527,8 @@ Members:
 
 --*/
 
+#pragma pack(push, 1)
+
 typedef struct _SATA_FIS_REGISTER_H2D {
     UCHAR Type;
     UCHAR Flags;
@@ -955,6 +957,8 @@ typedef struct _AHCI_RECEIVED_FIS {
     UCHAR UnknownFis[0x40];
     UCHAR Reserved[0x60];
 } PACKED AHCI_RECEIVED_FIS, *PAHCI_RECEIVED_FIS;
+
+#pragma pack(pop)
 
 /*++
 

--- a/drivers/ata/ata.h
+++ b/drivers/ata/ata.h
@@ -250,11 +250,15 @@ Members:
 
 --*/
 
+#pragma pack(push, 1)
+
 typedef struct _ATA_PRDT {
     ULONG PhysicalAddress;
     USHORT Size;
     USHORT Flags;
 } PACKED ATA_PRDT, *PATA_PRDT;
+
+#pragma pack(pop)
 
 /*++
 

--- a/drivers/net/ethernet/am3eth/am3eth.h
+++ b/drivers/net/ethernet/am3eth/am3eth.h
@@ -590,12 +590,16 @@ Members:
 
 --*/
 
+#pragma pack(push, 1)
+
 typedef struct _A3E_DESCRIPTOR {
     ULONG NextDescriptor;
     ULONG Buffer;
     ULONG BufferLengthOffset;
     ULONG PacketLengthFlags;
 } PACKED ALIGNED16 A3E_DESCRIPTOR, *PA3E_DESCRIPTOR;
+
+#pragma pack(pop)
 
 /*++
 

--- a/drivers/net/ethernet/atl1c/atl1c.h
+++ b/drivers/net/ethernet/atl1c/atl1c.h
@@ -862,6 +862,8 @@ Members:
 
 --*/
 
+#pragma pack(push, 1)
+
 typedef struct _ATL1C_TRANSMIT_DESCRIPTOR {
     USHORT BufferLength;
     USHORT VlanTag;
@@ -918,6 +920,8 @@ Members:
 typedef struct _ATL1C_RECEIVE_SLOT {
     ULONGLONG PhysicalAddress;
 } PACKED ATL1C_RECEIVE_SLOT, *PATL1C_RECEIVE_SLOT;
+
+#pragma pack(pop)
 
 /*++
 

--- a/drivers/net/ethernet/dwceth/dwceth.h
+++ b/drivers/net/ethernet/dwceth/dwceth.h
@@ -542,6 +542,8 @@ Members:
 
 --*/
 
+#pragma pack(push, 1)
+
 typedef struct _DWE_DESCRIPTOR {
     ULONG Control;
     ULONG BufferSize;
@@ -551,6 +553,8 @@ typedef struct _DWE_DESCRIPTOR {
     ULONG Reserved;
     ULONGLONG Timestamp;
 } PACKED DWE_DESCRIPTOR, *PDWE_DESCRIPTOR;
+
+#pragma pack(pop)
 
 /*++
 

--- a/drivers/net/ethernet/e100/e100.h
+++ b/drivers/net/ethernet/e100/e100.h
@@ -456,6 +456,8 @@ Members:
 
 --*/
 
+#pragma pack(push, 1)
+
 typedef struct _E100_COMMAND {
     volatile ULONG Command;
     ULONG NextCommand;
@@ -515,6 +517,8 @@ typedef struct _E100_RECEIVE_FRAME {
     ULONG Sizes;
     ULONG ReceiveFrame[RECEIVE_FRAME_DATA_SIZE / sizeof(ULONG)];
 } PACKED E100_RECEIVE_FRAME, *PE100_RECEIVE_FRAME;
+
+#pragma pack(pop)
 
 /*++
 

--- a/drivers/net/ethernet/e1000/e1000.h
+++ b/drivers/net/ethernet/e1000/e1000.h
@@ -861,6 +861,8 @@ Members:
 
 --*/
 
+#pragma pack(push, 1)
+
 typedef struct _E1000_TX_DESCRIPTOR {
     ULONGLONG Address;
     USHORT Length;
@@ -903,6 +905,8 @@ typedef struct _E1000_RX_DESCRIPTOR {
     UCHAR Errors;
     USHORT VlanTag;
 } PACKED E1000_RX_DESCRIPTOR, *PE1000_RX_DESCRIPTOR;
+
+#pragma pack(pop)
 
 /*++
 

--- a/drivers/net/ethernet/pcnet32/pcnet.h
+++ b/drivers/net/ethernet/pcnet32/pcnet.h
@@ -557,6 +557,8 @@ Members:
 
 --*/
 
+#pragma pack(push, 1)
+
 typedef struct _PCNET_INITIALIZATION_BLOCK_16 {
     USHORT Mode;
     BYTE PhysicalAddress[ETHERNET_ADDRESS_SIZE];
@@ -695,6 +697,8 @@ typedef struct _PCNET_TRANSMIT_DESCRIPTOR_32 {
     ULONG ErrorFlags;
     ULONG Reserved;
 } PACKED PCNET_TRANSMIT_DESCRIPTOR_32, *PPCNET_TRANSMIT_DESCRIPTOR_32;
+
+#pragma pack(pop)
 
 /*++
 

--- a/drivers/net/ethernet/rtl81xx/rtl81.h
+++ b/drivers/net/ethernet/rtl81xx/rtl81.h
@@ -835,6 +835,8 @@ Members:
 
 --*/
 
+#pragma pack(push, 1)
+
 typedef struct _RTL81_TRANSMIT_DESCRIPTOR {
     ULONG Command;
     ULONG VlanTag;
@@ -864,6 +866,8 @@ typedef struct _RTL81_RECEIVE_DESCRIPTOR {
     ULONG VlanTag;
     ULONGLONG PhysicalAddress;
 } PACKED RTL81_RECEIVE_DESCRIPTOR, *PRTL81_RECEIVE_DESCRIPTOR;
+
+#pragma pack(pop)
 
 /*++
 

--- a/drivers/net/net80211/eapol.c
+++ b/drivers/net/net80211/eapol.c
@@ -313,6 +313,8 @@ Members:
 
 --*/
 
+#pragma pack(push, 1)
+
 typedef struct _EAPOL_PACKET_HEADER {
     UCHAR ProtocolVersion;
     UCHAR Type;
@@ -421,6 +423,8 @@ typedef struct _EAPOL_KDE_GTK {
     UCHAR Reserved;
     UCHAR Gtk[ANYSIZE_ARRAY];
 } PACKED EAPOL_KDE_GTK, *PEAPOL_KDE_GTK;
+
+#pragma pack(pop)
 
 /*++
 

--- a/drivers/net/net80211/mgmt.c
+++ b/drivers/net/net80211/mgmt.c
@@ -175,6 +175,8 @@ Members:
 
 --*/
 
+#pragma pack(push, 1)
+
 typedef struct _NET80211_AUTHENTICATION_OPEN_BODY {
     USHORT AlgorithmNumber;
     USHORT TransactionSequenceNumber;
@@ -224,6 +226,8 @@ typedef struct _NET80211_DEFAULT_RSN_INFORMATION {
     ULONG AkmSuite;
     USHORT RsnCapabilities;
 } PACKED NET80211_DEFAULT_RSN_INFORMATION, *PNET80211_DEFAULT_RSN_INFORMATION;
+
+#pragma pack(pop)
 
 //
 // ----------------------------------------------- Internal Function Prototypes

--- a/drivers/net/netcore/ipv4/arp.c
+++ b/drivers/net/netcore/ipv4/arp.c
@@ -112,6 +112,8 @@ Members:
         receiver.
 --*/
 
+#pragma pack(push, 1)
+
 typedef struct _ARP_PACKET {
     USHORT HardwareType;
     USHORT ProtocolType;
@@ -119,6 +121,8 @@ typedef struct _ARP_PACKET {
     UCHAR ProtocolAddressLength;
     USHORT Operation;
 } PACKED ARP_PACKET, *PARP_PACKET;
+
+#pragma pack(pop)
 
 //
 // ----------------------------------------------- Internal Function Prototypes

--- a/drivers/net/netcore/ipv4/dhcp.c
+++ b/drivers/net/netcore/ipv4/dhcp.c
@@ -234,6 +234,8 @@ Members:
 
 --*/
 
+#pragma pack(push, 1)
+
 typedef struct _DHCP_PACKET {
     UCHAR OperationCode;
     UCHAR HardwareType;
@@ -251,6 +253,8 @@ typedef struct _DHCP_PACKET {
     UCHAR BootFileName[128];
     ULONG MagicCookie;
 } PACKED DHCP_PACKET, *PDHCP_PACKET;
+
+#pragma pack(pop)
 
 /*++
 

--- a/drivers/net/netcore/ipv4/igmp.c
+++ b/drivers/net/netcore/ipv4/igmp.c
@@ -217,6 +217,8 @@ Members:
 
 --*/
 
+#pragma pack(push, 1)
+
 typedef struct _IGMP_HEADER {
     UCHAR Type;
     UCHAR MaxResponseCode;
@@ -321,6 +323,8 @@ typedef struct _IGMP_REPORT_V3 {
     USHORT Reserved;
     USHORT GroupRecordCount;
 } PACKED IGMP_REPORT_V3, *PIGMP_REPORT_V3;
+
+#pragma pack(pop)
 
 /*++
 

--- a/drivers/net/netcore/ipv6/mld.c
+++ b/drivers/net/netcore/ipv6/mld.c
@@ -206,6 +206,8 @@ Members:
 
 --*/
 
+#pragma pack(push, 1)
+
 typedef struct _MLD_MESSAGE {
     ICMP6_HEADER Header;
     USHORT MaxResponseCode;
@@ -289,6 +291,8 @@ typedef struct _MLD2_ADDRESS_RECORD {
     USHORT SourceAddressCount;
     ULONG MulticastAddress[IP6_ADDRESS_SIZE / sizeof(ULONG)];
 } PACKED MLD2_ADDRESS_RECORD, *PMLD2_ADDRESS_RECORD;
+
+#pragma pack(pop)
 
 /*++
 

--- a/drivers/net/netcore/ipv6/ndp.c
+++ b/drivers/net/netcore/ipv6/ndp.c
@@ -137,6 +137,8 @@ Members:
 
 --*/
 
+#pragma pack(push, 1)
+
 typedef struct _NDP_ROUTER_SOLICITATION {
     ICMP6_HEADER Header;
     ULONG Reserved;
@@ -366,6 +368,8 @@ typedef struct _NDP_OPTION_MTU {
     USHORT Reserved;
     ULONG MaxTransmissionUnit;
 } PACKED NDP_OPTION_MTU, *PNDP_OPTION_MTU;
+
+#pragma pack(pop)
 
 /*++
 

--- a/drivers/net/netcore/tcp.h
+++ b/drivers/net/netcore/tcp.h
@@ -811,6 +811,8 @@ Members:
 
 --*/
 
+#pragma pack(push, 1)
+
 typedef struct _TCP_HEADER {
     USHORT SourcePort;
     USHORT DestinationPort;
@@ -822,6 +824,8 @@ typedef struct _TCP_HEADER {
     USHORT Checksum;
     USHORT NonUrgentOffset;
 } PACKED TCP_HEADER, *PTCP_HEADER;
+
+#pragma pack(pop)
 
 //
 // -------------------------------------------------------------------- Globals

--- a/drivers/net/netcore/udp.c
+++ b/drivers/net/netcore/udp.c
@@ -163,12 +163,16 @@ Members:
 
 --*/
 
+#pragma pack(push, 1)
+
 typedef struct _UDP_HEADER {
     USHORT SourcePort;
     USHORT DestinationPort;
     USHORT Length;
     USHORT Checksum;
 } PACKED UDP_HEADER, *PUDP_HEADER;
+
+#pragma pack(pop)
 
 /*++
 

--- a/drivers/net/wireless/rtlw81xx/rtlw81.h
+++ b/drivers/net/wireless/rtlw81xx/rtlw81.h
@@ -1610,6 +1610,8 @@ Members:
 
 --*/
 
+#pragma pack(push, 1)
+
 typedef struct _RTLW81_FIRMWARE_HEADER {
     USHORT Signature;
     UCHAR Category;
@@ -1863,6 +1865,8 @@ typedef struct _RTLW81_MAC_ID_CONFIG_COMMAND {
     ULONG Mask;
     UCHAR MacId;
 } PACKED RTLW81_MAC_ID_CONFIG_COMMAND, *PRTLW81_MAC_ID_CONFIG_COMMAND;
+
+#pragma pack(pop)
 
 /*++
 

--- a/drivers/pci/msi.c
+++ b/drivers/pci/msi.c
@@ -106,11 +106,15 @@ Environment:
 // ------------------------------------------------------ Data Type Definitions
 //
 
+#pragma pack(push, 1)
+
 typedef struct _PCI_MSI_X_TABLE_ENTRY {
     ULONGLONG Address;
     ULONG Data;
     ULONG Control;
 } PACKED PCI_MSI_X_TABLE_ENTRY, *PPCI_MSI_X_TABLE_ENTRY;
+
+#pragma pack(pop)
 
 //
 // ----------------------------------------------- Internal Function Prototypes

--- a/drivers/plat/goec/goecprot.h
+++ b/drivers/plat/goec/goecprot.h
@@ -284,6 +284,8 @@ Members:
 
 --*/
 
+#pragma pack(push, 1)
+
 typedef struct _GOEC_COMMAND_HEADER {
     UCHAR Version;
     UCHAR Checksum;
@@ -324,6 +326,8 @@ typedef struct _GOEC_RESPONSE_HEADER {
     USHORT DataLength;
     USHORT Reserved;
 } PACKED GOEC_RESPONSE_HEADER, *PGOEC_RESPONSE_HEADER;
+
+#pragma pack(pop)
 
 /*++
 
@@ -377,6 +381,8 @@ Members:
 
 --*/
 
+#pragma pack(push, 1)
+
 typedef struct _GOEC_PARAMS_HELLO {
     ULONG InData;
 } PACKED GOEC_PARAMS_HELLO, *PGOEC_PARAMS_HELLO;
@@ -396,6 +402,8 @@ Members:
 typedef struct _GOEC_RESPONSE_HELLO {
     ULONG OutData;
 } PACKED GOEC_RESPONSE_HELLO, *PGOEC_RESPONSE_HELLO;
+
+#pragma pack(pop)
 
 typedef enum _GOEC_CURRENT_IMAGE {
     GoecImageUnknown = 0,
@@ -420,6 +428,8 @@ Members:
     CurrentImage - Stores the current running image. See GOEC_CURRENT_IMAGE.
 
 --*/
+
+#pragma pack(push, 1)
 
 typedef struct _GOEC_RESPONSE_GET_VERSION {
     CHAR VersionStringRo[32];
@@ -543,6 +553,8 @@ Members:
 typedef struct _GOEC_RESPONSE_VBNV_CONTEXT {
     GOEC_NVRAM NvRam;
 } PACKED GOEC_RESPONSE_VBNV_CONTEXT, *PGOEC_RESPONSE_VBNV_CONTEXT;
+
+#pragma pack(pop)
 
 //
 // -------------------------------------------------------------------- Globals

--- a/drivers/sd/rk32xx/sdrk32.h
+++ b/drivers/sd/rk32xx/sdrk32.h
@@ -133,6 +133,8 @@ Members:
 
 --*/
 
+#pragma pack(push, 1)
+
 typedef struct _SD_RK32_VENDOR_RESOURCE {
     UCHAR SubType;
     UUID Uuid;
@@ -143,6 +145,8 @@ typedef struct _SD_RK32_VENDOR_RESOURCE {
     USHORT ClockSelectShift;
     ULONG ControlOffset;
 } PACKED SD_RK32_VENDOR_RESOURCE, *PSD_RK32_VENDOR_RESOURCE;
+
+#pragma pack(pop)
 
 typedef struct _SD_RK32_CONTEXT SD_RK32_CONTEXT, *PSD_RK32_CONTEXT;
 

--- a/drivers/sound/broadcom/bc27pwma/pwma.c
+++ b/drivers/sound/broadcom/bc27pwma/pwma.c
@@ -178,11 +178,15 @@ Members:
 
 --*/
 
+#pragma pack(push, 1)
+
 typedef struct _BCM27_PWMA_DEVICE {
     SOUND_DEVICE SoundDevice;
     ULONG SampleRates[BCM27_PWMA_SAMPLE_RATE_COUNT];
     SOUND_DEVICE_ROUTE Routes[BCM27_PWMA_ROUTE_COUNT];
 } PACKED BCM27_PWMA_DEVICE, *PBCM27_PWMA_DEVICE;
+
+#pragma pack(pop)
 
 /*++
 

--- a/drivers/sound/intel/hda/hdahw.h
+++ b/drivers/sound/intel/hda/hdahw.h
@@ -1042,6 +1042,8 @@ Members:
 
 --*/
 
+#pragma pack(push, 1)
+
 typedef struct _HDA_BUFFER_DESCRIPTOR_LIST_ENTRY {
     ULONGLONG Address;
     ULONG Length;
@@ -1084,6 +1086,8 @@ typedef struct _HDA_RESPONSE_ENTRY {
     ULONG Response;
     ULONG ResponseExtended;
 } PACKED HDA_RESPONSE_ENTRY, *PHDA_RESPONSE_ENTRY;
+
+#pragma pack(pop)
 
 //
 // -------------------------------------------------------------------- Globals

--- a/drivers/usb/ehci/ehcihw.h
+++ b/drivers/usb/ehci/ehcihw.h
@@ -282,6 +282,8 @@ Members:
 
 --*/
 
+#pragma pack(push, 1)
+
 typedef struct _EHCI_TRANSFER_DESCRIPTOR {
     ULONG NextTransfer;
     ULONG AlternateNextTransfer;
@@ -372,6 +374,8 @@ Members:
 typedef struct _EHCI_PERIODIC_SCHEDULE {
     ULONG FrameLink[EHCI_DEFAULT_FRAME_LIST_ENTRY_COUNT];
 } PACKED EHCI_PERIODIC_SCHEDULE, *PEHCI_PERIODIC_SCHEDULE;
+
+#pragma pack(pop)
 
 //
 // -------------------------------------------------------------------- Globals

--- a/drivers/usb/uhci/uhcihw.h
+++ b/drivers/usb/uhci/uhcihw.h
@@ -209,6 +209,8 @@ Members:
 
 --*/
 
+#pragma pack(push, 1)
+
 typedef struct _UHCI_TRANSFER_DESCRIPTOR {
     ULONG LinkPointer;
     ULONG Status;
@@ -257,6 +259,8 @@ Members:
 typedef struct _UHCI_SCHEDULE {
     ULONG Frame[UHCI_FRAME_LIST_ENTRY_COUNT];
 } PACKED UHCI_SCHEDULE, *PUHCI_SCHEDULE;
+
+#pragma pack(pop)
 
 //
 // -------------------------------------------------------------------- Globals

--- a/drivers/usb/usbkbd/usbkbd.h
+++ b/drivers/usb/usbkbd/usbkbd.h
@@ -98,11 +98,15 @@ Members:
 
 --*/
 
+#pragma pack(push, 1)
+
 typedef struct _USB_KEYBOARD_REPORT {
     UCHAR ModifierKeys;
     UCHAR Reserved;
     UCHAR Keycode[USB_KEYBOARD_REPORT_KEY_COUNT];
 } PACKED USB_KEYBOARD_REPORT, *PUSB_KEYBOARD_REPORT;
+
+#pragma pack(pop)
 
 //
 // -------------------------------------------------------------------- Globals

--- a/drivers/usb/usbmass/usbmass.c
+++ b/drivers/usb/usbmass/usbmass.c
@@ -421,6 +421,8 @@ Members:
 
 --*/
 
+#pragma pack(push, 1)
+
 typedef struct _SCSI_COMMAND_BLOCK {
     ULONG Signature;
     ULONG Tag;
@@ -571,6 +573,8 @@ typedef struct _SCSI_CAPACITY {
     ULONG LastValidBlockAddress;
     ULONG BlockLength;
 } PACKED SCSI_CAPACITY, *PSCSI_CAPACITY;
+
+#pragma pack(pop)
 
 //
 // ----------------------------------------------- Internal Function Prototypes

--- a/include/minoca/debug/dbgproto.h
+++ b/include/minoca/debug/dbgproto.h
@@ -137,6 +137,8 @@ Members:
 
 --*/
 
+#pragma pack(push, 1)
+
 typedef struct _DEBUG_PACKET_HEADER {
     USHORT Magic;
     USHORT Command;
@@ -168,6 +170,8 @@ typedef struct _DEBUG_PACKET {
     DEBUG_PACKET_HEADER Header;
     UCHAR Payload[DEBUG_PAYLOAD_SIZE];
 } PACKED DEBUG_PACKET, *PDEBUG_PACKET;
+
+#pragma pack(pop)
 
 typedef enum _DEBUGGER_COMMAND {
     DbgInvalidCommand,
@@ -239,6 +243,8 @@ Members:
         immediate breakpoint (TRUE) or just wants to connect (FALSE).
 
 --*/
+
+#pragma pack(push, 1)
 
 typedef struct _CONNECTION_REQUEST {
     ULONG ProtocolMajorVersion;
@@ -449,10 +455,14 @@ typedef union _REGISTERS_UNION {
     ARM_GENERAL_REGISTERS Arm;
 } PACKED REGISTERS_UNION, *PREGISTERS_UNION;
 
+#pragma pack(pop)
+
 typedef struct _X86_TABLE_REGISTER {
     ULONG Limit;
     ULONG Base;
 } X86_TABLE_REGISTER, *PX86_TABLE_REGISTER;
+
+#pragma pack(push, 1)
 
 typedef struct _X86_SPECIAL_REGISTERS {
     ULONGLONG Cr0;
@@ -855,6 +865,8 @@ Members:
 typedef struct _DEBUG_REBOOT_REQUEST {
     ULONG ResetType;
 } PACKED DEBUG_REBOOT_REQUEST, *PDEBUG_REBOOT_REQUEST;
+
+#pragma pack(pop)
 
 //
 // ----------------------------------------------- Internal Function Prototypes

--- a/include/minoca/debug/spproto.h
+++ b/include/minoca/debug/spproto.h
@@ -142,6 +142,8 @@ Members:
 
 --*/
 
+#pragma pack(push, 1)
+
 typedef struct _PROFILER_NOTIFICATION_HEADER {
     PROFILER_DATA_TYPE Type;
     ULONG Processor;
@@ -168,6 +170,8 @@ typedef struct _PROFILER_NOTIFICATION {
     PROFILER_NOTIFICATION_HEADER Header;
     BYTE Data[PROFILER_NOTIFICATION_SIZE];
 } PACKED PROFILER_NOTIFICATION, *PPROFILER_NOTIFICATION;
+
+#pragma pack(pop)
 
 /*++
 
@@ -226,6 +230,8 @@ Members:
         initialization.
 
 --*/
+
+#pragma pack(push, 1)
 
 typedef struct _PROFILER_MEMORY_POOL {
     ULONG Magic;
@@ -406,6 +412,8 @@ typedef struct _PROFILER_THREAD_NEW_THREAD {
     ULONGLONG TimeCounter;
     CHAR Name[ANYSIZE_ARRAY];
 } PACKED PROFILER_THREAD_NEW_THREAD, *PPROFILER_THREAD_NEW_THREAD;
+
+#pragma pack(pop)
 
 //
 // -------------------------------------------------------------------- Globals

--- a/include/minoca/dma/dmab2709.h
+++ b/include/minoca/dma/dmab2709.h
@@ -270,6 +270,8 @@ Members:
 
 --*/
 
+#pragma pack(push, 1)
+
 typedef struct _DMA_BCM2709_CONTROL_BLOCK {
     ULONG TransferInformation;
     ULONG SourceAddress;
@@ -279,6 +281,8 @@ typedef struct _DMA_BCM2709_CONTROL_BLOCK {
     ULONG NextAddress;
     ULONG Reserved[2];
 } PACKED DMA_BCM2709_CONTROL_BLOCK, *PDMA_BCM2709_CONTROL_BLOCK;
+
+#pragma pack(pop)
 
 //
 // -------------------------------------------------------------------- Globals

--- a/include/minoca/dma/edma3.h
+++ b/include/minoca/dma/edma3.h
@@ -238,6 +238,8 @@ Members:
 
 --*/
 
+#pragma pack(push, 1)
+
 typedef struct _EDMA_PARAM {
     ULONG Options;
     ULONG Source;
@@ -253,6 +255,8 @@ typedef struct _EDMA_PARAM {
     USHORT CCount;
     USHORT Reserved;
 } PACKED EDMA_PARAM, *PEDMA_PARAM;
+
+#pragma pack(pop)
 
 /*++
 

--- a/include/minoca/fw/acpitabs.h
+++ b/include/minoca/fw/acpitabs.h
@@ -807,6 +807,8 @@ Members:
 
 --*/
 
+#pragma pack(push, 1)
+
 typedef struct _GENERIC_ADDRESS {
     UCHAR AddressSpaceId;
     UCHAR RegisterBitWidth;
@@ -1663,6 +1665,8 @@ typedef struct _GTDT {
     ULONG NonSecurePl2Gsi;
     ULONG NonSecurePl2Flags;
 } PACKED GTDT, *PGTDT;
+
+#pragma pack(pop)
 
 //
 // -------------------------------------------------------------------- Globals

--- a/include/minoca/fw/smbios.h
+++ b/include/minoca/fw/smbios.h
@@ -633,6 +633,8 @@ Members:
 
 --*/
 
+#pragma pack(push, 1)
+
 typedef struct _SMBIOS_ENTRY_POINT {
     ULONG AnchorString;
     UCHAR Checksum;
@@ -1472,6 +1474,8 @@ typedef struct _SMBIOS_BOOT_INFORMATION {
     UCHAR Reserved[6];
     UCHAR BootStatus[ANYSIZE_ARRAY];
 } PACKED SMBIOS_BOOT_INFORMATION, *PSMBIOS_BOOT_INFORMATION;
+
+#pragma pack(pop)
 
 //
 // -------------------------------------------------------------------- Globals

--- a/include/minoca/kernel/arm.h
+++ b/include/minoca/kernel/arm.h
@@ -659,10 +659,14 @@ Members:
 
 --*/
 
+#pragma pack(push, 1)
+
 struct _FPU_CONTEXT {
     ULONGLONG Registers[32];
     ULONG Fpscr;
 } PACKED ALIGNED16;
+
+#pragma pack(pop)
 
 /*++
 
@@ -720,11 +724,15 @@ Members:
 
 --*/
 
+#pragma pack(push, 1)
+
 typedef struct _SIGNAL_CONTEXT_ARM {
     SIGNAL_CONTEXT Common;
     TRAP_FRAME TrapFrame;
     FPU_CONTEXT FpuContext;
 } PACKED SIGNAL_CONTEXT_ARM, *PSIGNAL_CONTEXT_ARM;
+
+#pragma pack(pop)
 
 /*++
 
@@ -1079,6 +1087,8 @@ Members:
 
 --*/
 
+#pragma pack(push, 1)
+
 typedef struct _ARM_CPUID {
     ULONG ProcessorFeatures[2];
     ULONG DebugFeatures;
@@ -1086,6 +1096,8 @@ typedef struct _ARM_CPUID {
     ULONG MemoryModelFeatures[4];
     ULONG IsaFeatures[6];
 } PACKED ARM_CPUID, *PARM_CPUID;
+
+#pragma pack(pop)
 
 /*++
 

--- a/include/minoca/kernel/bootload.h
+++ b/include/minoca/kernel/bootload.h
@@ -362,6 +362,8 @@ Members:
 
 --*/
 
+#pragma pack(push, 1)
+
 struct _PROCESSOR_START_BLOCK {
     PVOID StackBase;
     ULONG StackSize;
@@ -371,6 +373,8 @@ struct _PROCESSOR_START_BLOCK {
     PVOID ProcessorStructures;
     PVOID SwapPage;
 } PACKED;
+
+#pragma pack(pop)
 
 //
 // -------------------------------------------------------------------- Globals

--- a/include/minoca/kernel/crashdmp.h
+++ b/include/minoca/kernel/crashdmp.h
@@ -88,6 +88,8 @@ Members:
 
 --*/
 
+#pragma pack(push, 1)
+
 typedef struct _CRASH_DUMP_HEADER {
     ULONG Signature;
     CRASH_DUMP_TYPE Type;
@@ -108,6 +110,8 @@ typedef struct _CRASH_DUMP_HEADER {
     ULONGLONG Parameter3;
     ULONGLONG Parameter4;
 } PACKED CRASH_DUMP_HEADER, *PCRASH_DUMP_HEADER;
+
+#pragma pack(pop)
 
 //
 // -------------------------------------------------------- Function Prototypes

--- a/include/minoca/kernel/io.h
+++ b/include/minoca/kernel/io.h
@@ -1544,12 +1544,16 @@ Members:
 
 --*/
 
+#pragma pack(push, 1)
+
 typedef struct _DIRECTORY_ENTRY {
     FILE_ID FileId;
     ULONGLONG NextOffset;
     USHORT Size;
     UCHAR Type;
 } PACKED DIRECTORY_ENTRY, *PDIRECTORY_ENTRY;
+
+#pragma pack(pop)
 
 /*++
 

--- a/include/minoca/kernel/x64.h
+++ b/include/minoca/kernel/x64.h
@@ -159,6 +159,8 @@ Members:
 
 --*/
 
+#pragma pack(push, 1)
+
 typedef struct _PROCESSOR_GATE {
     USHORT LowOffset;
     USHORT Selector;
@@ -382,6 +384,8 @@ struct _FPU_CONTEXT {
     UCHAR Xmm15[16];
     UCHAR Padding[96];
 } PACKED ALIGNED64;
+
+#pragma pack(pop)
 
 /*++
 

--- a/include/minoca/kernel/x86.h
+++ b/include/minoca/kernel/x86.h
@@ -68,6 +68,8 @@ Members:
 
 --*/
 
+#pragma pack(push, 1)
+
 typedef struct _PROCESSOR_GATE {
     USHORT LowOffset;
     USHORT Selector;
@@ -510,6 +512,8 @@ struct _PROCESSOR_CONTEXT {
     TABLE_REGISTER Idt;
     TABLE_REGISTER Gdt;
 } PACKED;
+
+#pragma pack(pop)
 
 typedef
 VOID

--- a/include/minoca/lib/fat/fatlib.h
+++ b/include/minoca/lib/fat/fatlib.h
@@ -288,6 +288,8 @@ Members:
 
 --*/
 
+#pragma pack(push, 1)
+
 typedef struct _FAT_EXTENDED_BIOS_PARAMETERS {
     BYTE PhysicalDriveNumber;
     BYTE CurrentHead;
@@ -594,6 +596,8 @@ typedef struct _FAT_LONG_DIRECTORY_ENTRY {
     USHORT Cluster;
     USHORT Name3[FAT_LONG_DIRECTORY_ENTRY_NAME3_SIZE];
 } PACKED FAT_LONG_DIRECTORY_ENTRY, *PFAT_LONG_DIRECTORY_ENTRY;
+
+#pragma pack(pop)
 
 //
 // -------------------------------------------------------- Function Prototypes

--- a/include/minoca/lib/tzfmt.h
+++ b/include/minoca/lib/tzfmt.h
@@ -133,6 +133,8 @@ Members:
 
 --*/
 
+#pragma pack(push, 1)
+
 typedef struct _TIME_ZONE_HEADER {
     ULONG Magic;
     ULONG RuleOffset;
@@ -302,6 +304,8 @@ typedef struct _TIME_ZONE_LEAP_SECOND {
     CHAR LocalTime;
     CHAR Padding;
 } PACKED TIME_ZONE_LEAP_SECOND, *PTIME_ZONE_LEAP_SECOND;
+
+#pragma pack(pop)
 
 //
 // -------------------------------------------------------------------- Globals

--- a/include/minoca/net/ip4.h
+++ b/include/minoca/net/ip4.h
@@ -174,6 +174,8 @@ Members:
 
 --*/
 
+#pragma pack(push, 1)
+
 typedef struct _IP4_HEADER {
     UCHAR VersionAndHeaderLength;
     UCHAR Type;
@@ -206,6 +208,8 @@ typedef struct _IP4_OPTION {
     UCHAR Type;
     UCHAR Length;
 } PACKED IP4_OPTION, *PIP4_OPTION;
+
+#pragma pack(pop)
 
 //
 // -------------------------------------------------------------------- Globals

--- a/include/minoca/net/ip6.h
+++ b/include/minoca/net/ip6.h
@@ -216,6 +216,8 @@ Members:
 
 --*/
 
+#pragma pack(push, 1)
+
 typedef struct _IP6_HEADER {
     ULONG VersionClassFlow;
     USHORT PayloadLength;
@@ -265,6 +267,8 @@ typedef struct _IP6_OPTION {
     UCHAR Type;
     UCHAR Length;
 } PACKED IP6_OPTION, *PIP6_OPTION;
+
+#pragma pack(pop)
 
 //
 // -------------------------------------------------------------------- Globals

--- a/include/minoca/net/net80211.h
+++ b/include/minoca/net/net80211.h
@@ -666,6 +666,8 @@ Members:
 
 --*/
 
+#pragma pack(push, 1)
+
 typedef struct _NET80211_FRAME_HEADER {
     USHORT FrameControl;
     USHORT DurationId;
@@ -830,6 +832,8 @@ typedef struct _NET80211_CCM_NONCE {
     UCHAR Address2[NET80211_ADDRESS_SIZE];
     UCHAR PacketNumber[NET80211_CCMP_PACKET_NUMBER_SIZE];
 } PACKED NET80211_CCM_NONCE, *PNET80211_CCM_NONCE;
+
+#pragma pack(pop)
 
 typedef enum _NET80211_STATE {
     Net80211StateInvalid,

--- a/include/minoca/net/net8022.h
+++ b/include/minoca/net/net8022.h
@@ -68,6 +68,8 @@ Members:
 
 --*/
 
+#pragma pack(push, 1)
+
 typedef struct _NET8022_LLC_HEADER {
     UCHAR DestinationSapAddress;
     UCHAR SourceSapAddress;
@@ -93,6 +95,8 @@ typedef struct _NET8022_SNAP_EXTENSION {
     UCHAR OrganizationCode[3];
     USHORT EthernetType;
 } PACKED NET8022_SNAP_EXTENSION, *PNET8022_SNAP_EXTENSION;
+
+#pragma pack(pop)
 
 //
 // -------------------------------------------------------------------- Globals

--- a/include/minoca/net/netlink.h
+++ b/include/minoca/net/netlink.h
@@ -356,6 +356,8 @@ Members:
 
 --*/
 
+#pragma pack(push, 1)
+
 typedef struct _NETLINK_HEADER {
     ULONG Length;
     USHORT Type;
@@ -424,6 +426,8 @@ typedef struct _NETLINK_GENERIC_HEADER {
     UCHAR Version;
     USHORT Reserved;
 } PACKED NETLINK_GENERIC_HEADER, *PNETLINK_GENERIC_HEADER;
+
+#pragma pack(pop)
 
 /*++
 

--- a/include/minoca/sd/sd.h
+++ b/include/minoca/sd/sd.h
@@ -762,6 +762,8 @@ Members:
 
 --*/
 
+#pragma pack(push, 1)
+
 typedef struct _SD_CARD_IDENTIFICATION {
     UCHAR Crc7;
     UCHAR ManufacturingDate[2];
@@ -792,6 +794,8 @@ typedef struct _SD_ADMA2_DESCRIPTOR {
     ULONG Attributes;
     ULONG Address;
 } PACKED SD_ADMA2_DESCRIPTOR, *PSD_ADMA2_DESCRIPTOR;
+
+#pragma pack(pop)
 
 //
 // -------------------------------------------------------------------- Globals

--- a/include/minoca/sd/sddwc.h
+++ b/include/minoca/sd/sddwc.h
@@ -400,12 +400,16 @@ Members:
 
 --*/
 
+#pragma pack(push, 1)
+
 typedef struct _SD_DWC_DMA_DESCRIPTOR {
     ULONG Control;
     ULONG Size;
     ULONG Address;
     ULONG NextDescriptor;
 } PACKED SD_DWC_DMA_DESCRIPTOR, *PSD_DWC_DMA_DESCRIPTOR;
+
+#pragma pack(pop)
 
 //
 // -------------------------------------------------------------------- Globals

--- a/include/minoca/soc/b2709os.h
+++ b/include/minoca/soc/b2709os.h
@@ -100,6 +100,8 @@ Members:
 
 --*/
 
+#pragma pack(push, 1)
+
 typedef struct _BCM2709_TABLE {
     DESCRIPTION_HEADER Header;
     ULONGLONG ApbClockFrequency;
@@ -175,6 +177,8 @@ typedef struct _BCM2709_CPU_ENTRY {
     ULONG ParkingProtocolVersion;
     ULONGLONG ParkedAddress;
 } PACKED BCM2709_CPU_ENTRY, *PBCM2709_CPU_ENTRY;
+
+#pragma pack(pop)
 
 //
 // -------------------------------------------------------------------- Globals

--- a/include/minoca/storage/ata.h
+++ b/include/minoca/storage/ata.h
@@ -203,6 +203,8 @@ Members:
 
 --*/
 
+#pragma pack(push, 1)
+
 typedef struct _ATA_IDENTIFY_PACKET {
     USHORT Configuration;
     USHORT Reserved1[9];
@@ -253,6 +255,8 @@ typedef struct _ATA_IDENTIFY_PACKET {
     USHORT Reserved13[49];
     USHORT Checksum;
 } PACKED ATA_IDENTIFY_PACKET, *PATA_IDENTIFY_PACKET;
+
+#pragma pack(pop)
 
 //
 // -------------------------------------------------------------------- Globals

--- a/include/minoca/uefi/protocol/devpath.h
+++ b/include/minoca/uefi/protocol/devpath.h
@@ -489,6 +489,8 @@ Members:
 
 --*/
 
+#pragma pack(push, 1)
+
 typedef struct {
     UINT8 Type;
     UINT8 SubType;
@@ -1640,6 +1642,8 @@ typedef union {
     BBS_BBS_DEVICE_PATH *Bbs;
     UINT8 *Raw;
 } PACKED EFI_DEV_PATH_PTR;
+
+#pragma pack(pop)
 
 //
 // -------------------------------------------------------------------- Globals

--- a/include/minoca/uefi/spec.h
+++ b/include/minoca/uefi/spec.h
@@ -3221,12 +3221,16 @@ Members:
 
 --*/
 
+#pragma pack(push, 1)
+
 typedef struct {
     EFI_BOOT_KEY_DATA KeyData;
     UINT32 BootOptionCrc;
     UINT16 BootOption;
     //EFI_INPUT_KEY Keys[];
 } PACKED EFI_KEY_OPTION;
+
+#pragma pack(pop)
 
 //
 // -------------------------------------------------------------------- Globals

--- a/include/minoca/usb/usb.h
+++ b/include/minoca/usb/usb.h
@@ -479,6 +479,8 @@ Members:
 
 --*/
 
+#pragma pack(push, 1)
+
 typedef struct _USB_DEVICE_DESCRIPTOR {
     UCHAR Length;
     UCHAR DescriptorType;
@@ -793,6 +795,8 @@ typedef struct _USB_SETUP_PACKET {
     USHORT Index;
     USHORT Length;
 } PACKED USB_SETUP_PACKET, *PUSB_SETUP_PACKET;
+
+#pragma pack(pop)
 
 /*++
 

--- a/kernel/hl/armv7/am335.h
+++ b/kernel/hl/armv7/am335.h
@@ -72,6 +72,8 @@ Members:
 
 --*/
 
+#pragma pack(push, 1)
+
 typedef struct _AM335X_TABLE {
     DESCRIPTION_HEADER Header;
     ULONGLONG TimerBase[AM335X_TIMER_COUNT];
@@ -80,6 +82,8 @@ typedef struct _AM335X_TABLE {
     ULONGLONG InterruptControllerBase;
     ULONGLONG PrcmBase;
 } PACKED AM335X_TABLE, *PAM335X_TABLE;
+
+#pragma pack(pop)
 
 //
 // -------------------------------------------------------------------- Globals

--- a/kernel/hl/armv7/integcp.h
+++ b/kernel/hl/armv7/integcp.h
@@ -108,6 +108,8 @@ Members:
 
 --*/
 
+#pragma pack(push, 1)
+
 typedef struct _INTEGRATORCP_TABLE {
     DESCRIPTION_HEADER Header;
     ULONGLONG Pl110PhysicalAddress;
@@ -118,6 +120,8 @@ typedef struct _INTEGRATORCP_TABLE {
     ULONGLONG DebugUartPhysicalAddress;
     ULONG DebugUartClockFrequency;
 } PACKED INTEGRATORCP_TABLE, *PINTEGRATORCP_TABLE;
+
+#pragma pack(pop)
 
 //
 // -------------------------------------------------------------------- Globals

--- a/kernel/hl/armv7/omap3.h
+++ b/kernel/hl/armv7/omap3.h
@@ -123,6 +123,8 @@ Members:
 
 --*/
 
+#pragma pack(push, 1)
+
 typedef struct _OMAP3_TABLE {
     DESCRIPTION_HEADER Header;
     ULONGLONG InterruptControllerPhysicalAddress;
@@ -132,6 +134,8 @@ typedef struct _OMAP3_TABLE {
     ULONGLONG PrcmPhysicalAddress;
     ULONGLONG DebugUartPhysicalAddress;
 } PACKED OMAP3_TABLE, *POMAP3_TABLE;
+
+#pragma pack(pop)
 
 //
 // -------------------------------------------------------------------- Globals

--- a/kernel/hl/armv7/omap4.h
+++ b/kernel/hl/armv7/omap4.h
@@ -133,6 +133,8 @@ Members:
 
 --*/
 
+#pragma pack(push, 1)
+
 typedef struct _OMAP4_TABLE {
     DESCRIPTION_HEADER Header;
     ULONGLONG TimerPhysicalAddress[OMAP4_TIMER_COUNT];
@@ -143,6 +145,8 @@ typedef struct _OMAP4_TABLE {
     ULONGLONG AudioClockPhysicalAddress;
     ULONGLONG Pl310RegistersBasePhysicalAddress;
 } PACKED OMAP4_TABLE, *POMAP4_TABLE;
+
+#pragma pack(pop)
 
 //
 // -------------------------------------------------------------------- Globals

--- a/kernel/hl/armv7/realview.h
+++ b/kernel/hl/armv7/realview.h
@@ -81,6 +81,8 @@ Members:
 
 --*/
 
+#pragma pack(push, 1)
+
 typedef struct _REALVIEW_TABLE {
     DESCRIPTION_HEADER Header;
     ULONGLONG Pl110PhysicalAddress;
@@ -90,6 +92,8 @@ typedef struct _REALVIEW_TABLE {
     ULONGLONG DebugUartPhysicalAddress;
     ULONG DebugUartClockFrequency;
 } PACKED REALVIEW_TABLE, *PREALVIEW_TABLE;
+
+#pragma pack(pop)
 
 //
 // -------------------------------------------------------------------- Globals

--- a/kernel/hl/armv7/rk32xx.h
+++ b/kernel/hl/armv7/rk32xx.h
@@ -73,6 +73,8 @@ Members:
 
 --*/
 
+#pragma pack(push, 1)
+
 typedef struct _RK32XX_TABLE {
     DESCRIPTION_HEADER Header;
     ULONGLONG TimerBase[RK32_TIMER_COUNT];
@@ -80,6 +82,8 @@ typedef struct _RK32XX_TABLE {
     ULONG TimerCountDownMask;
     ULONG TimerEnabledMask;
 } PACKED RK32XX_TABLE, *PRK32XX_TABLE;
+
+#pragma pack(pop)
 
 //
 // -------------------------------------------------------------------- Globals

--- a/lib/bconflib/bconfp.h
+++ b/lib/bconflib/bconfp.h
@@ -98,6 +98,8 @@ Members:
 
 --*/
 
+#pragma pack(push, 1)
+
 typedef struct _BOOT_CONFIGURATION_HEADER {
     ULONG Magic;
     ULONG Version;
@@ -171,6 +173,8 @@ typedef struct _BOOT_CONFIGURATION_ENTRY {
     ULONGLONG Flags;
     ULONG DebugDevice;
 } PACKED BOOT_CONFIGURATION_ENTRY, *PBOOT_CONFIGURATION_ENTRY;
+
+#pragma pack(pop)
 
 //
 // -------------------------------------------------------------------- Globals

--- a/lib/im/elf.h
+++ b/lib/im/elf.h
@@ -378,6 +378,8 @@ Members:
 
 --*/
 
+#pragma pack(push, 1)
+
 typedef struct _ELF32_HEADER {
     UCHAR Identification[ELF32_IDENTIFICATION_LENGTH];
     ELF32_HALF ImageType;
@@ -873,6 +875,8 @@ typedef struct _ELF64_DYNAMIC_ENTRY {
     ELF64_SXWORD Tag;
     ELF64_XWORD Value;
 } PACKED ELF64_DYNAMIC_ENTRY, *PELF64_DYNAMIC_ENTRY;
+
+#pragma pack(pop)
 
 //
 // -------------------------------------------------------------------- Globals

--- a/lib/im/pe.h
+++ b/lib/im/pe.h
@@ -105,6 +105,8 @@ Author:
 // PE Image header definitions.
 //
 
+#pragma pack(push, 1)
+
 typedef struct _IMAGE_SECTION_HEADER {
     BYTE Name[IMAGE_SIZEOF_SHORT_NAME];
     union {
@@ -209,6 +211,8 @@ typedef struct _PE_RELOCATION_BLOCK {
     ULONG BlockSizeInBytes;
 } PACKED PE_RELOCATION_BLOCK, *PPE_RELOCATION_BLOCK;
 
+#pragma pack(pop)
+
 typedef USHORT PE_RELOCATION, *PPE_RELOCATION;
 
 typedef enum _PE_RELOCATION_TYPE {
@@ -221,6 +225,8 @@ typedef enum _PE_RELOCATION_TYPE {
     PeRelocationMipsJumpAddress16 = 9,
     PeRelocation64 = 10
 } PE_RELOCATION_TYPE, *PPE_RELOCATION_TYPE;
+
+#pragma pack(push, 1)
 
 typedef struct _PE_EXPORT_DIRECTORY_TABLE {
     ULONG ExportFlags;
@@ -266,6 +272,8 @@ typedef struct _COFF_SYMBOL {
     UCHAR Class;
     UCHAR AuxCount;
 } PACKED COFF_SYMBOL, *PCOFF_SYMBOL;
+
+#pragma pack(pop)
 
 //
 // -------------------------------------------------------- Function Prototypes

--- a/lib/partlib/partlibp.h
+++ b/lib/partlib/partlibp.h
@@ -173,6 +173,8 @@ Members:
 
 --*/
 
+#pragma pack(push, 1)
+
 typedef struct _PARTITION_TABLE_ENTRY {
     UCHAR BootIndicator;
     UCHAR StartingHead;
@@ -285,6 +287,8 @@ typedef struct _GPT_PARTITION_ENTRY {
     ULONGLONG Attributes;
     USHORT Name[36];
 } PACKED GPT_PARTITION_ENTRY, *PGPT_PARTITION_ENTRY;
+
+#pragma pack(pop)
 
 /*++
 

--- a/uefi/core/partfmt.h
+++ b/uefi/core/partfmt.h
@@ -157,6 +157,8 @@ Members:
 
 --*/
 
+#pragma pack(push, 1)
+
 typedef struct _EFI_PARTITION_TABLE_HEADER {
     EFI_TABLE_HEADER Header;
     EFI_LBA MyLba;
@@ -281,6 +283,7 @@ typedef struct _EFI_CDROM_PRIMARY_VOLUME_DESCRIPTOR {
     UINT32 VolumeSize[2];
 } PACKED EFI_CDROM_PRIMARY_VOLUME_DESCRIPTOR,
                                          *PEFI_CDROM_PRIMARY_VOLUME_DESCRIPTOR;
+#pragma pack(pop)
 
 /*++
 
@@ -322,6 +325,8 @@ Members:
     Id55AA - Stores the constant values 0x55 and 0xAA.
 
 --*/
+
+#pragma pack(push, 1)
 
 typedef struct _EFI_ELTORITO_CATALOG_DATA {
     UINT8 Indicator;
@@ -391,6 +396,8 @@ typedef struct _EFI_ELTORITO_SECTION {
     CHAR8 Id[28];
 } PACKED EFI_ELTORITO_SECTION, *PEFI_ELTORITO_SECTION;
 
+#pragma pack(pop)
+
 /*++
 
 Structure Description:
@@ -449,6 +456,8 @@ Members:
 
 --*/
 
+#pragma pack(push, 1)
+
 typedef struct _EFI_MBR_PARTITION_RECORD {
     UINT8 BootIndicator;
     UINT8 StartHead;
@@ -491,6 +500,8 @@ typedef struct _EFI_MASTER_BOOT_RECORD {
     EFI_MBR_PARTITION_RECORD Partition[EFI_MAX_MBR_PARTITIONS];
     UINT16 Signature;
 } PACKED EFI_MASTER_BOOT_RECORD, *PEFI_MASTER_BOOT_RECORD;
+
+#pragma pack(pop)
 
 //
 // -------------------------------------------------------------------- Globals

--- a/uefi/core/ramdisk.c
+++ b/uefi/core/ramdisk.c
@@ -124,10 +124,14 @@ Members:
 
 --*/
 
+#pragma pack(push, 1)
+
 typedef struct _EFI_RAM_DISK_DEVICE_PATH {
     EFI_RAM_DISK_DEVICE_PATH_NODE Disk;
     EFI_DEVICE_PATH_PROTOCOL End;
 } PACKED EFI_RAM_DISK_DEVICE_PATH, *PEFI_RAM_DISK_DEVICE_PATH;
+
+#pragma pack(pop)
 
 //
 // ----------------------------------------------- Internal Function Prototypes

--- a/uefi/dev/bcm2709/sd.c
+++ b/uefi/dev/bcm2709/sd.c
@@ -186,10 +186,14 @@ Members:
 
 --*/
 
+#pragma pack(push, 1)
+
 typedef struct _EFI_SD_BCM2709_DEVICE_PATH {
     EFI_SD_BCM2709_BLOCK_IO_DEVICE_PATH Disk;
     EFI_DEVICE_PATH_PROTOCOL End;
 } PACKED EFI_SD_BCM2709_DEVICE_PATH, *PEFI_SD_BCM2709_DEVICE_PATH;
+
+#pragma pack(pop)
 
 //
 // ----------------------------------------------- Internal Function Prototypes

--- a/uefi/dev/bcm2709/serial.c
+++ b/uefi/dev/bcm2709/serial.c
@@ -125,10 +125,14 @@ Members:
 
 --*/
 
+#pragma pack(push, 1)
+
 typedef struct _EFI_BCM2709_SERIAL_IO_DEVICE_PATH {
     EFI_BCM2709_SERIAL_IO_DEVICE_PATH_NODE Device;
     EFI_DEVICE_PATH_PROTOCOL End;
 } PACKED EFI_BCM2709_SERIAL_IO_DEVICE_PATH, *PEFI_BCM2709_SERIAL_IO_DEVICE_PATH;
+
+#pragma pack(pop)
 
 //
 // ----------------------------------------------- Internal Function Prototypes

--- a/uefi/include/dev/sd.h
+++ b/uefi/include/dev/sd.h
@@ -424,6 +424,8 @@ Members:
 
 --*/
 
+#pragma pack(push, 1)
+
 typedef struct _SD_CARD_IDENTIFICATION {
     UINT8 Crc7;
     UINT8 ManufacturingDate[2];
@@ -433,6 +435,8 @@ typedef struct _SD_CARD_IDENTIFICATION {
     UINT8 OemId[2];
     UINT8 ManufacturerId;
 } PACKED SD_CARD_IDENTIFICATION, *PSD_CARD_IDENTIFICATION;
+
+#pragma pack(pop)
 
 //
 // -------------------------------------------------------------------- Globals

--- a/uefi/include/dev/tirom.h
+++ b/uefi/include/dev/tirom.h
@@ -120,6 +120,8 @@ Members:
 
 --*/
 
+#pragma pack(push, 1)
+
 typedef struct _AM335_BOOT_DATA {
     UINT32 Reserved;
     UINT32 MemoryDeviceDescriptor;
@@ -127,6 +129,8 @@ typedef struct _AM335_BOOT_DATA {
     UINT8 ResetReason;
     UINT8 Reserved2;
 } PACKED AM335_BOOT_DATA, *PAM335_BOOT_DATA;
+
+#pragma pack(pop)
 
 typedef
 INT32

--- a/uefi/include/efiimg.h
+++ b/uefi/include/efiimg.h
@@ -117,6 +117,8 @@ Author:
 typedef UINT8 EFI_FV_FILETYPE, *PEFI_FV_FILETYPE;
 typedef UINT8 EFI_SECTION_TYPE, *PEFI_SECTION_TYPE;
 
+#pragma pack(push, 1)
+
 typedef union _EFI_COMMON_SECTION_HEADER {
     struct {
         UINT8 Size[3];
@@ -199,6 +201,8 @@ typedef struct _EFI_FREEFORM_SUBTYPE_GUID_SECTION {
 typedef struct _EFI_RAW_SECTION {
     EFI_COMMON_SECTION_HEADER CommonHeader;
 } PACKED EFI_RAW_SECTION, *PEFI_RAW_SECTION;
+
+#pragma pack(pop)
 
 typedef union _EFI_FILE_SECTION_POINTER {
     EFI_COMMON_SECTION_HEADER *CommonHeader;

--- a/uefi/include/fwvol.h
+++ b/uefi/include/fwvol.h
@@ -149,6 +149,8 @@ Author:
 
 typedef UINT32 EFI_FVB_ATTRIBUTES, *PEFI_FVB_ATTRIBUTES;
 
+#pragma pack(push, 1)
+
 typedef struct _EFI_FIRMWARE_VOLUME_EXT_ENTRY {
     UINT16 ExtEntrySize;
     UINT16 ExtEntryType;
@@ -191,6 +193,8 @@ typedef struct {
     UINT8 Revision;
     EFI_FV_BLOCK_MAP_ENTRY BlockMap[1];
 } PACKED EFI_FIRMWARE_VOLUME_HEADER;
+
+#pragma pack(pop)
 
 //
 // -------------------------------------------------------------------- Globals

--- a/uefi/include/uboot.h
+++ b/uefi/include/uboot.h
@@ -191,6 +191,8 @@ Members:
 
 --*/
 
+#pragma pack(push, 1)
+
 typedef struct _UBOOT_HEADER {
     UINT32 Magic;
     UINT32 HeaderCrc32;
@@ -323,6 +325,8 @@ typedef struct _UBOOT_FIT_PROPERTY {
     UINT32 StringOffset;
     // UINT8 Data[Size];
 } PACKED UBOOT_FIT_PROPERTY, *PUBOOT_FIT_PROPERTY;
+
+#pragma pack(pop)
 
 //
 // -------------------------------------------------------------------- Globals

--- a/uefi/plat/beagbone/sd.c
+++ b/uefi/plat/beagbone/sd.c
@@ -199,10 +199,14 @@ Members:
 
 --*/
 
+#pragma pack(push, 1)
+
 typedef struct _EFI_SD_AM335_DEVICE_PATH {
     EFI_SD_AM335_BLOCK_IO_DEVICE_PATH Disk;
     EFI_DEVICE_PATH_PROTOCOL End;
 } PACKED EFI_SD_AM335_DEVICE_PATH, *PEFI_SD_AM335_DEVICE_PATH;
+
+#pragma pack(pop)
 
 //
 // ----------------------------------------------- Internal Function Prototypes

--- a/uefi/plat/beagbone/serial.c
+++ b/uefi/plat/beagbone/serial.c
@@ -125,10 +125,14 @@ Members:
 
 --*/
 
+#pragma pack(push, 1)
+
 typedef struct _EFI_BBONE_SERIAL_IO_DEVICE_PATH {
     EFI_BBONE_SERIAL_IO_DEVICE_PATH_NODE Device;
     EFI_DEVICE_PATH_PROTOCOL End;
 } PACKED EFI_BBONE_SERIAL_IO_DEVICE_PATH, *PEFI_BBONE_SERIAL_IO_DEVICE_PATH;
+
+#pragma pack(pop)
 
 //
 // ----------------------------------------------- Internal Function Prototypes

--- a/uefi/plat/beagbone/smbios.c
+++ b/uefi/plat/beagbone/smbios.c
@@ -90,6 +90,8 @@ Members:
 
 --*/
 
+#pragma pack(push, 1)
+
 typedef struct _EFI_BBONE_EEPROM {
     UINT32 Header;
     UINT8 BoardName[BBONE_BLACK_BOARD_NAME_SIZE];
@@ -98,6 +100,8 @@ typedef struct _EFI_BBONE_EEPROM {
     UINT8 Configuration[BBONE_BLACK_CONFIGURATION_OPTIONS_SIZE];
     UINT8 Reserved[BBONE_BLACK_RESERVED_SIZE];
 } PACKED EFI_BBONE_EEPROM, *PEFI_BBONE_EEPROM;
+
+#pragma pack(pop)
 
 //
 // ----------------------------------------------- Internal Function Prototypes

--- a/uefi/plat/bios/biosfw.h
+++ b/uefi/plat/bios/biosfw.h
@@ -133,6 +133,8 @@ Members:
 
 --*/
 
+#pragma pack(push, 1)
+
 typedef struct _INT13_DISK_ACCESS_PACKET {
     UINT8 PacketSize;
     UINT8 Reserved;
@@ -183,6 +185,8 @@ typedef struct _INT13_EXTENDED_DRIVE_PARAMETERS {
     UINT16 SectorSize;
     UINT32 EnhancedDiskInformation;
 } PACKED INT13_EXTENDED_DRIVE_PARAMETERS, *PINT13_EXTENDED_DRIVE_PARAMETERS;
+
+#pragma pack(pop)
 
 //
 // -------------------------------------------------------------------- Globals

--- a/uefi/plat/bios/disk.c
+++ b/uefi/plat/bios/disk.c
@@ -144,10 +144,14 @@ Members:
 
 --*/
 
+#pragma pack(push, 1)
+
 typedef struct _EFI_PCAT_DISK_DEVICE_PATH {
     EFI_BIOS_BLOCK_IO_DEVICE_PATH Disk;
     EFI_DEVICE_PATH_PROTOCOL End;
 } PACKED EFI_PCAT_DISK_DEVICE_PATH, *PEFI_PCAT_DISK_DEVICE_PATH;
+
+#pragma pack(pop)
 
 //
 // ----------------------------------------------- Internal Function Prototypes

--- a/uefi/plat/bios/video.c
+++ b/uefi/plat/bios/video.c
@@ -163,6 +163,8 @@ Members:
 
 --*/
 
+#pragma pack(push, 1)
+
 typedef struct _VESA_INFORMATION {
     UINT32 Signature;
     UINT16 VesaVersion;
@@ -321,6 +323,8 @@ typedef struct _VESA_MODE_INFORMATION {
     UINT16 OffScreenMemorySize;
     //UCHAR Reserved2[206];
 } PACKED VESA_MODE_INFORMATION, *PVESA_MODE_INFORMATION;
+
+#pragma pack(pop)
 
 /*++
 

--- a/uefi/plat/integcp/serial.c
+++ b/uefi/plat/integcp/serial.c
@@ -125,11 +125,15 @@ Members:
 
 --*/
 
+#pragma pack(push, 1)
+
 typedef struct _EFI_INTEGRATOR_SERIAL_IO_DEVICE_PATH {
     EFI_INTEGRATOR_SERIAL_IO_DEVICE_PATH_NODE Device;
     EFI_DEVICE_PATH_PROTOCOL End;
 } PACKED EFI_INTEGRATOR_SERIAL_IO_DEVICE_PATH,
     *PEFI_INTEGRATOR_SERIAL_IO_DEVICE_PATH;
+
+#pragma pack(pop)
 
 //
 // ----------------------------------------------- Internal Function Prototypes

--- a/uefi/plat/panda/init/fatboot.c
+++ b/uefi/plat/panda/init/fatboot.c
@@ -124,6 +124,8 @@ Members:
 
 --*/
 
+#pragma pack(push, 1)
+
 typedef struct _PARTITION_TABLE_ENTRY {
     UCHAR BootIndicator;
     UCHAR StartingHead;
@@ -136,6 +138,8 @@ typedef struct _PARTITION_TABLE_ENTRY {
     ULONG StartingLba;
     ULONG SectorCount;
 } PACKED PARTITION_TABLE_ENTRY, *PPARTITION_TABLE_ENTRY;
+
+#pragma pack(pop)
 
 //
 // ----------------------------------------------- Internal Function Prototypes

--- a/uefi/plat/panda/sd.c
+++ b/uefi/plat/panda/sd.c
@@ -197,10 +197,14 @@ Members:
 
 --*/
 
+#pragma pack(push, 1)
+
 typedef struct _EFI_SD_OMAP4_DEVICE_PATH {
     EFI_SD_OMAP4_BLOCK_IO_DEVICE_PATH Disk;
     EFI_DEVICE_PATH_PROTOCOL End;
 } PACKED EFI_SD_OMAP4_DEVICE_PATH, *PEFI_SD_OMAP4_DEVICE_PATH;
+
+#pragma pack(pop)
 
 //
 // ----------------------------------------------- Internal Function Prototypes

--- a/uefi/plat/panda/serial.c
+++ b/uefi/plat/panda/serial.c
@@ -123,10 +123,14 @@ Members:
 
 --*/
 
+#pragma pack(push, 1)
+
 typedef struct _EFI_PANDA_SERIAL_IO_DEVICE_PATH {
     EFI_PANDA_SERIAL_IO_DEVICE_PATH_NODE Device;
     EFI_DEVICE_PATH_PROTOCOL End;
 } PACKED EFI_PANDA_SERIAL_IO_DEVICE_PATH, *PEFI_PANDA_SERIAL_IO_DEVICE_PATH;
+
+#pragma pack(pop)
 
 //
 // ----------------------------------------------- Internal Function Prototypes

--- a/uefi/plat/veyron/fwbuild/fwbuild.c
+++ b/uefi/plat/veyron/fwbuild/fwbuild.c
@@ -86,6 +86,8 @@ Members:
 
 --*/
 
+#pragma pack(push, 1)
+
 typedef struct _VERIFIED_BOOT_SIGNATURE {
     ULONGLONG SignatureOffset;
     ULONGLONG SignatureSize;
@@ -134,6 +136,8 @@ typedef struct _VERIFIED_BOOT_PREAMBLE_HEADER {
     ULONGLONG BootLoaderSize;
     VERIFIED_BOOT_SIGNATURE ImageSignature;
 } PACKED VERIFIED_BOOT_PREAMBLE_HEADER, *PVERIFIED_BOOT_PREAMBLE_HEADER;
+
+#pragma pack(pop)
 
 //
 // ----------------------------------------------- Internal Function Prototypes

--- a/uefi/plat/veyron/sd.c
+++ b/uefi/plat/veyron/sd.c
@@ -169,10 +169,14 @@ Members:
 
 --*/
 
+#pragma pack(push, 1)
+
 typedef struct _EFI_SD_RK32_DEVICE_PATH {
     EFI_SD_RK32_BLOCK_IO_DEVICE_PATH Disk;
     EFI_DEVICE_PATH_PROTOCOL End;
 } PACKED EFI_SD_RK32_DEVICE_PATH, *PEFI_SD_RK32_DEVICE_PATH;
+
+#pragma pack(pop)
 
 //
 // ----------------------------------------------- Internal Function Prototypes

--- a/uefi/plat/veyron/serial.c
+++ b/uefi/plat/veyron/serial.c
@@ -124,10 +124,14 @@ Members:
 
 --*/
 
+#pragma pack(push, 1)
+
 typedef struct _EFI_VEYRON_SERIAL_IO_DEVICE_PATH {
     EFI_VEYRON_SERIAL_IO_DEVICE_PATH_NODE Device;
     EFI_DEVICE_PATH_PROTOCOL End;
 } PACKED EFI_VEYRON_SERIAL_IO_DEVICE_PATH, *PEFI_VEYRON_SERIAL_IO_DEVICE_PATH;
+
+#pragma pack(pop)
 
 //
 // ----------------------------------------------- Internal Function Prototypes


### PR DESCRIPTION
This changed adds pragmas around packed structures, since Microsoft's
compiler does not recognize __attribute__((packed)).